### PR TITLE
Cobbler insttaltion behind internet proxy need changes in settings.j2

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ansible-galaxy-cobbler</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+	</buildSpec>
+	<natures>
+	</natures>
+</projectDescription>

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,10 @@ cobbler_dynamic_bootp_end: 192.168.168.172
 cobbler_routers: 192.168.168.1
 cobbler_domain_name_servers: 192.168.168.1
 cobbler_subnet_mask: 255.255.255.0
+# If cobbler is behind a proxy for  download from internet , the http_proxy settings in environment doesn't help
+# to complete the installation . It fails during "cobbler get-loaders " tasks . Proxy has to be explicitly 
+#mentioned in the /etc/cobbler/settings file . Hence modified the template and inserting this additional var 
+ext_proxy_for_cobbler: http://10.0.0.14:3128 
 
 
 

--- a/templates/etc/cobbler/settings.j2
+++ b/templates/etc/cobbler/settings.j2
@@ -455,8 +455,11 @@ always_write_dhcp_entries: 0
 
 # external proxy - used by: get-loaders, reposync, signature update
 # eg: proxy_url_ext: "http://192.168.1.1:8080"
+{% if ext_proxy_for_cobbler is defined %}
+proxy_url_ext: {{ ext_proxy_for_cobbler }}
+{% else %}
 proxy_url_ext: ""
-
+{% endif %}
 # internal proxy - used by systems to reach cobbler for kickstarts
 # eg: proxy_url_int: "http://10.0.0.1:8080"
 proxy_url_int: ""


### PR DESCRIPTION
# If cobbler is behind a proxy for  download from internet , the http_proxy settings in environment doesn't help  to complete the installation . It fails during "cobbler get-loaders " tasks . Proxy has to be explicitly 
#mentioned in the /etc/cobbler/settings file . Hence modified the template  settings.j2  and inserting this additional var  in default variables 
ext_proxy_for_cobbler: http://10.0.0.14:3128 